### PR TITLE
Derive Field Names From Field Instruction Bundles

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { render, screen } from "@testing-library/react";
+import App from "./App";
 
-test('renders application header', () => {
+test("renders application header", () => {
   render(<App />);
   const applicationHeader = screen.getByText(/application/i);
   expect(applicationHeader).toBeInTheDocument();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,3 @@
-import "./App.css";
-
 import Application from "./containers/Application/Application";
 
 function App() {

--- a/src/components/ButtonToggle/ButtonToggle.tsx
+++ b/src/components/ButtonToggle/ButtonToggle.tsx
@@ -14,14 +14,13 @@ interface ButtonConfig {
   buttonType?: "button" | "submit";
 }
 
-const ButtonToggle: (
-  props: FieldProps<ButtonToggleConfig>
-) => JSX.Element = (props) => {
-  const { fieldConfig, fieldKit, className } = props;
+const ButtonToggle: (props: FieldProps<ButtonToggleConfig>) => JSX.Element = (
+  props
+) => {
+  const { fieldName, fieldConfig, fieldKit, className } = props;
 
   const { buttonConfigs } = fieldConfig;
-  const elemName = fieldConfig.name;
-  const validationError = fieldKit.errors[elemName];
+  const validationError = fieldKit.errors[fieldName];
 
   const clickHandler = (name: string, value: any) => {
     fieldKit.setFieldValue(name, value);
@@ -31,23 +30,23 @@ const ButtonToggle: (
     <div className={className || fieldConfig.className}>
       <div className="row">
         <InputLabel
-          labelFor={elemName}
+          labelFor={fieldName}
           labelText={fieldConfig.labelText}
           className="mt-2 mb-1 text-nowrap"
         />
         <div className="col-12">
-          <div className="row" onBlur={fieldKit.handleBlur(elemName)}>
+          <div className="row" onBlur={fieldKit.handleBlur(fieldName)}>
             {buttonConfigs.map((btnConfig: ButtonConfig) => {
               return (
                 <div
-                  key={`${elemName}${btnConfig.text}${btnConfig.value}`}
+                  key={`${fieldName}${btnConfig.text}${btnConfig.value}`}
                   className={btnConfig.divClassName}
                 >
                   <button
                     type={btnConfig.buttonType || "button"}
-                    onClick={() => clickHandler(elemName, btnConfig.value)}
+                    onClick={() => clickHandler(fieldName, btnConfig.value)}
                     className={`btn ${
-                      btnConfig.value === fieldKit.values[elemName]
+                      btnConfig.value === fieldKit.values[fieldName]
                         ? "btn-primary"
                         : "btn-outline-secondary"
                     }`}
@@ -60,7 +59,7 @@ const ButtonToggle: (
           </div>
         </div>
       </div>
-      {validationError && fieldKit.touched[elemName] ? (
+      {validationError && fieldKit.touched[fieldName] ? (
         <div style={{ color: "red" }}>{validationError}</div>
       ) : null}
     </div>

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import {  FieldConfig, FieldProps } from "../../forms/fieldInstructions";
+import { FieldConfig, FieldProps } from "../../forms/fieldInstructions";
 import InputLabel from "../InputLabel/InputLabel";
 
 export interface CheckboxConfig extends FieldConfig {
@@ -11,25 +11,24 @@ export interface CheckboxConfig extends FieldConfig {
  * General component which renders a checkbox
  */
 const Checkbox = (props: FieldProps<CheckboxConfig>) => {
-  const { fieldConfig, fieldKit, className } = props;
-  const elemName = fieldConfig.name;
+  const { fieldName, fieldConfig, fieldKit, className } = props;
 
   return (
     <div className={className || fieldConfig.className}>
       <div className="form-check">
         <input
           type="checkbox"
-          id={fieldConfig.id || elemName}
-          name={elemName}
-          value={fieldKit.values[elemName]}
-          checked={fieldKit.values[elemName] || false}
+          id={fieldConfig.id || fieldName}
+          name={fieldName}
+          value={fieldKit.values[fieldName]}
+          checked={fieldKit.values[fieldName] || false}
           onChange={fieldKit.handleChange}
           onBlur={fieldKit.handleBlur}
           className="form-check-input"
           {...fieldConfig.other}
         />
         <InputLabel
-          labelFor={elemName}
+          labelFor={fieldName}
           labelText={fieldConfig.labelText}
           className="form-check-label"
         />

--- a/src/components/FieldBuilder/FieldBuilder.tsx
+++ b/src/components/FieldBuilder/FieldBuilder.tsx
@@ -2,13 +2,14 @@ import { FieldKit } from "../../forms/formUtils";
 import { FieldInstructionAny } from "../../forms/fieldInstructions";
 
 interface FieldBuilderProps {
+  fieldName: string;
   fieldInstructionAny: FieldInstructionAny;
   fieldKit: FieldKit;
   className?: string;
 }
 
 const FieldBuilder: (props: FieldBuilderProps) => JSX.Element = (props) => {
-  const { fieldInstructionAny, fieldKit, className } = props;
+  const { fieldName, fieldInstructionAny, fieldKit, className } = props;
 
   const fieldInstruction =
     typeof fieldInstructionAny === "function"
@@ -19,6 +20,7 @@ const FieldBuilder: (props: FieldBuilderProps) => JSX.Element = (props) => {
 
   return (
     <Component
+      fieldName={fieldName}
       fieldConfig={fieldInstruction.config}
       fieldKit={fieldKit}
       className={className}

--- a/src/components/FieldGroup/FieldGroup.tsx
+++ b/src/components/FieldGroup/FieldGroup.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import FieldBuilder from "../FieldBuilder/FieldBuilder";
-import { keyFromFieldConfig } from "../../forms/formUtils";
 import { FieldKit } from "../../forms/formUtils";
 import { FieldInstructionBundle } from "../../forms/fieldInstructions";
 
@@ -11,14 +10,18 @@ interface FieldGroupProps {
 }
 
 const FieldGroup = (props: FieldGroupProps) => {
-  const fieldInstructionArray = Object.values(props.fieldInstructionBundle);
-  const elements = fieldInstructionArray.map((inputConfig) => (
-    <FieldBuilder
-      key={keyFromFieldConfig(inputConfig)}
-      fieldInstructionAny={inputConfig}
-      fieldKit={props.fieldKit}
-    />
-  ));
+  const fieldNames = Object.keys(props.fieldInstructionBundle);
+  const elements = fieldNames.map((fieldName) => {
+    const inputConfig = props.fieldInstructionBundle[fieldName];
+    return (
+      <FieldBuilder
+        key={fieldName}
+        fieldName={fieldName}
+        fieldInstructionAny={inputConfig}
+        fieldKit={props.fieldKit}
+      />
+    );
+  });
 
   return <React.Fragment>{elements}</React.Fragment>;
 };

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -14,30 +14,29 @@ export interface InputConfig extends FieldConfig {
  * depending on the configuration provided.
  */
 const Input = (props: FieldProps<InputConfig>) => {
-  const { className, fieldConfig, fieldKit } = props;
+  const { fieldName, className, fieldConfig, fieldKit } = props;
 
-  const elemName = fieldConfig.name;
-  const validationError = fieldKit.errors[elemName];
+  const validationError = fieldKit.errors[fieldName];
 
   return (
     <div className={className || fieldConfig.className}>
       <InputLabel
-        labelFor={elemName}
+        labelFor={fieldName}
         labelText={fieldConfig.labelText}
         className="mt-2 mb-1 text-nowrap"
       />
       <input
         type={fieldConfig.inputType}
-        id={fieldConfig.id || elemName}
-        name={elemName}
-        value={fieldKit.values[elemName]}
+        id={fieldConfig.id || fieldName}
+        name={fieldName}
+        value={fieldKit.values[fieldName]}
         onChange={fieldKit.handleChange}
         onBlur={fieldKit.handleBlur}
         className="form-control"
         placeholder={fieldConfig.placeholder}
         {...fieldConfig.other}
       />
-      {validationError && fieldKit.touched[elemName] ? (
+      {validationError && fieldKit.touched[fieldName] ? (
         <div style={{ color: "red" }}>{validationError}</div>
       ) : null}
     </div>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -16,21 +16,20 @@ export interface SelectConfig extends FieldConfig {
  * General component which renders a labeled select input
  */
 const Select = (props: FieldProps<SelectConfig>) => {
-  const { fieldConfig, fieldKit, className } = props;
-  const elemName = fieldConfig.name;
-  const validationError = fieldKit.errors[elemName];
+  const { fieldName, fieldConfig, fieldKit, className } = props;
+  const validationError = fieldKit.errors[fieldName];
 
   return (
     <div className={className || fieldConfig.className}>
       <InputLabel
-        labelFor={elemName}
+        labelFor={fieldName}
         labelText={fieldConfig.labelText}
         className="mt-2 mb-1 text-nowrap"
       />
       <select
-        id={fieldConfig.id || elemName}
-        name={elemName}
-        value={fieldKit.values[elemName]}
+        id={fieldConfig.id || fieldName}
+        name={fieldName}
+        value={fieldKit.values[fieldName]}
         onChange={fieldKit.handleChange}
         onBlur={fieldKit.handleBlur}
         className="form-select"
@@ -42,7 +41,7 @@ const Select = (props: FieldProps<SelectConfig>) => {
           </option>
         ))}
       </select>
-      {validationError && fieldKit.touched[elemName] ? (
+      {validationError && fieldKit.touched[fieldName] ? (
         <div style={{ color: "red" }}>{validationError}</div>
       ) : null}
     </div>

--- a/src/forms/ApplicationForm/ApplicationForm.tsx
+++ b/src/forms/ApplicationForm/ApplicationForm.tsx
@@ -14,7 +14,6 @@ import {
 const customInput: FieldInstruction<InputConfig> = {
   Component: Input,
   config: {
-    name: "customInput",
     labelText: <span className="text-warning">Customized Input</span>,
     inputType: "text",
     className: "col-12",

--- a/src/forms/fieldInstructions/fieldInstructionBundles.ts
+++ b/src/forms/fieldInstructions/fieldInstructionBundles.ts
@@ -1,12 +1,13 @@
 import * as fieldInstructions from "./index";
+import { FieldInstructionBundle } from "../fieldInstructions/index";
 
-export const vehicleGroupInputs = {
+export const vehicleGroupInputs: FieldInstructionBundle = {
   vehicleMake: fieldInstructions.vehicleMake,
   vehicleModel: fieldInstructions.vehicleModel,
   hasTradeIn: fieldInstructions.hasTradeIn,
 };
 
-export const applicantGroupInputs = {
+export const applicantGroupInputs: FieldInstructionBundle = {
   hasCoapplicant: fieldInstructions.hasCoapplicant,
   firstName: fieldInstructions.firstName,
   middleInitial: fieldInstructions.middleInitial,
@@ -17,7 +18,7 @@ export const applicantGroupInputs = {
   yearsAtResidence: fieldInstructions.yearsAtResidence,
 };
 
-export const coapplicantGroupInputs = {
+export const coapplicantGroupInputs: FieldInstructionBundle = {
   coapplicantFirstName: fieldInstructions.coapplicantFirstName,
   coapplicantMiddleInitial: fieldInstructions.coapplicantMiddleInitial,
   coapplicantLastName: fieldInstructions.coapplicantLastName,

--- a/src/forms/fieldInstructions/index.tsx
+++ b/src/forms/fieldInstructions/index.tsx
@@ -9,14 +9,13 @@ import Select, { SelectConfig } from "../../components/Select/Select";
 import { FormValues, FieldKit } from "../formUtils";
 
 export interface FieldConfig {
-  type?: string;
-  name: string;
-  validator: Validator;
+  validator?: Validator;
   initialValue?: any;
   id?: string;
 }
 
 export interface FieldProps<FC extends FieldConfig> {
+  fieldName: string;
   fieldConfig: FC;
   fieldKit: FieldKit;
   className?: string;
@@ -43,7 +42,8 @@ export interface FieldInstructionBundle {
 type Validator =
   | yup.AnySchema
   | null
-  | ((values: FormValues) => yup.AnySchema | null);
+  | undefined
+  | ((values: FormValues) => yup.AnySchema | null | undefined);
 
 /**
  * Utility function for copying the validator of an applicant field, for the co-applicant,
@@ -52,8 +52,8 @@ type Validator =
  */
 const buildCoapplicantValidator = <FC extends FieldConfig>(
   fieldInstruction: FieldInstruction<FC>
-): ((values: FormValues) => yup.AnySchema | null) => {
-  return (values) => {
+) => {
+  return (values: FormValues) => {
     if (!values.hasCoapplicant) {
       return null; // no validation when no co-applicant
     }
@@ -70,7 +70,6 @@ const buildCoapplicantValidator = <FC extends FieldConfig>(
 export const firstName: FieldInstruction<InputConfig> = {
   Component: Input,
   config: {
-    name: "firstName",
     labelText: "First Name",
     inputType: "text",
     className: "col-5",
@@ -81,7 +80,6 @@ export const firstName: FieldInstruction<InputConfig> = {
 export const middleInitial: FieldInstruction<InputConfig> = {
   Component: Input,
   config: {
-    name: "middleInitial",
     labelText: "Middle Initial",
     inputType: "text",
     className: "col-2",
@@ -92,7 +90,6 @@ export const middleInitial: FieldInstruction<InputConfig> = {
 export const lastName: FieldInstruction<InputConfig> = {
   Component: Input,
   config: {
-    name: "lastName",
     labelText: "Last Name",
     inputType: "text",
     className: "col-5",
@@ -103,7 +100,6 @@ export const lastName: FieldInstruction<InputConfig> = {
 export const streetAddr: FieldInstruction<InputConfig> = {
   Component: Input,
   config: {
-    name: "streetAddr",
     labelText: "Street Address",
     inputType: "text",
     className: "col-10",
@@ -114,7 +110,6 @@ export const streetAddr: FieldInstruction<InputConfig> = {
 export const city: FieldInstruction<InputConfig> = {
   Component: Input,
   config: {
-    name: "city",
     labelText: "City",
     inputType: "text",
     className: "col-6",
@@ -125,7 +120,6 @@ export const city: FieldInstruction<InputConfig> = {
 export const state: FieldInstruction<InputConfig> = {
   Component: Input,
   config: {
-    name: "state",
     labelText: "State",
     inputType: "text",
     className: "col-2",
@@ -140,7 +134,6 @@ export const state: FieldInstruction<InputConfig> = {
 export const yearsAtResidence: FieldInstruction<InputConfig> = {
   Component: Input,
   config: {
-    name: "yearsAtResidence",
     labelText: "Years At Residence",
     inputType: "number",
     className: "col-2",
@@ -161,7 +154,6 @@ export const yearsAtResidence: FieldInstruction<InputConfig> = {
 export const vehicleMake: FieldInstruction<SelectConfig> = {
   Component: Select,
   config: {
-    name: "vehicleMake",
     labelText: "Vehicle Make",
     className: "col-6",
     options: [
@@ -177,7 +169,6 @@ export const vehicleMake: FieldInstruction<SelectConfig> = {
 export const vehicleModel: FieldInstruction<SelectConfig> = {
   Component: Select,
   config: {
-    name: "vehicleModel",
     labelText: "Vehicle Model",
     className: "col-6",
     options: [
@@ -189,11 +180,11 @@ export const vehicleModel: FieldInstruction<SelectConfig> = {
     validator: yup.string().required("Required"),
   },
 };
+
 export const coapplicantFirstName: FieldInstruction<InputConfig> = {
   ...firstName,
   config: {
     ...firstName.config,
-    name: "coapplicantFirstName",
     validator: buildCoapplicantValidator(firstName),
   },
 };
@@ -202,7 +193,6 @@ export const coapplicantMiddleInitial: FieldInstruction<InputConfig> = {
   ...middleInitial,
   config: {
     ...middleInitial.config,
-    name: "coapplicantMiddleInitial",
     validator: buildCoapplicantValidator(middleInitial),
   },
 };
@@ -211,7 +201,6 @@ export const coapplicantLastName: FieldInstruction<InputConfig> = {
   ...lastName,
   config: {
     ...lastName.config,
-    name: "coapplicantLastName",
     validator: buildCoapplicantValidator(lastName),
   },
 };
@@ -220,7 +209,6 @@ export const coapplicantStreetAddr: FieldInstruction<InputConfig> = {
   ...streetAddr,
   config: {
     ...streetAddr.config,
-    name: "coapplicantStreetAddr",
     validator: buildCoapplicantValidator(streetAddr),
   },
 };
@@ -229,7 +217,6 @@ export const coapplicantCity: FieldInstruction<InputConfig> = {
   ...city,
   config: {
     ...city.config,
-    name: "coapplicantCity",
     validator: buildCoapplicantValidator(city),
   },
 };
@@ -238,7 +225,6 @@ export const coapplicantState: FieldInstruction<InputConfig> = {
   ...state,
   config: {
     ...state.config,
-    name: "coapplicantState",
     validator: buildCoapplicantValidator(state),
   },
 };
@@ -247,7 +233,6 @@ export const coapplicantYearsAtResidence: FieldInstruction<InputConfig> = {
   ...yearsAtResidence,
   config: {
     ...yearsAtResidence.config,
-    name: "coapplicantYearsAtResidence",
     validator: buildCoapplicantValidator(yearsAtResidence),
   },
 };
@@ -255,7 +240,6 @@ export const coapplicantYearsAtResidence: FieldInstruction<InputConfig> = {
 export const hasTradeIn: FieldInstruction<ButtonToggleConfig> = {
   Component: ButtonToggle,
   config: {
-    name: "hasTradeIn",
     labelText: "Has Trade In",
     validator: yup.boolean().required("Required"),
     initialValue: false,
@@ -286,7 +270,7 @@ export const hasCoapplicant: FieldInstructionCreator<CheckboxConfig> = (
     fieldKit.touched.coapplicantFirstName
   ) {
     scolding = (
-      <i style={{ color: "red" }}> (do you really have a Co-Applicant...?)</i>
+      <i style={{ color: "pink" }}> (do you really have a Co-Applicant...?)</i>
     );
   }
 
@@ -298,7 +282,6 @@ export const hasCoapplicant: FieldInstructionCreator<CheckboxConfig> = (
   return {
     Component: Checkbox,
     config: {
-      name: "hasCoapplicant",
       labelText: (
         <span>
           {label}

--- a/src/forms/fieldInstructions/index.tsx
+++ b/src/forms/fieldInstructions/index.tsx
@@ -278,7 +278,6 @@ export const hasCoapplicant: FieldInstructionCreator<CheckboxConfig> = (
     ? "Remove Co-Applicant"
     : "Add Co-Applicant";
 
-
   return {
     Component: Checkbox,
     config: {

--- a/src/forms/formUtils.ts
+++ b/src/forms/formUtils.ts
@@ -18,14 +18,14 @@ const configFromFieldInstructionAny = <FC extends FieldConfig>(
 ): FC => {
   if (typeof fieldInstructionAny === "function") {
     const noOpFieldKit = {
-        values: {},
-        errors: {},
-        touched: {},
-        handleChange: () => {},
-        handleBlur: () => {},
-        setFieldValue: () => {},
-        setFieldTouched: () => {},
-        setFieldError: () => {},
+      values: {},
+      errors: {},
+      touched: {},
+      handleChange: () => {},
+      handleBlur: () => {},
+      setFieldValue: () => {},
+      setFieldTouched: () => {},
+      setFieldError: () => {},
     };
     return fieldInstructionAny({}, noOpFieldKit).config;
   }
@@ -33,26 +33,27 @@ const configFromFieldInstructionAny = <FC extends FieldConfig>(
 };
 
 export const initialValuesFromFieldInstructionBundle = (
-  inputConfigs: FieldInstructionBundle
+  fieldsBundle: FieldInstructionBundle
 ) => {
   const allowFalsyInitialValueTypes = ["boolean", "number"];
 
-  const inputsArray = Object.values(inputConfigs);
-  return inputsArray.reduce((acc: { [key: string]: any }, inputConfig) => {
+  const fieldNames = Object.keys(fieldsBundle);
+  return fieldNames.reduce((acc: { [key: string]: any }, fieldName) => {
+    const inputConfig = fieldsBundle[fieldName];
     const config = configFromFieldInstructionAny(inputConfig);
     const value = allowFalsyInitialValueTypes.includes(
       typeof config.initialValue
     )
       ? config.initialValue
       : config.initialValue || "";
-    acc[config.name] = value;
+    acc[fieldName] = value;
     return acc;
   }, {});
 };
 
 export type FormValues = FormikValues;
 export type FormActions = FormikHelpers<FormValues>;
-type FieldKitErrors = {[K in keyof FormValues]: string}
+type FieldKitErrors = { [K in keyof FormValues]: string };
 
 export interface FieldKit {
   values: FormValues;
@@ -92,30 +93,24 @@ export const mapFormikPropsToFormKit: (
   };
 };
 
-export const keyFromFieldConfig = (inputConfig: FieldInstructionAny) => {
-  const config = configFromFieldInstructionAny(inputConfig);
-  return config.id || config.name;
-};
-
 export const validationSchemaFromFieldInstructionBundle = (
   fieldInstructionBundle: FieldInstructionBundle
 ) => {
   return yup.lazy((formValues: FormValues) => {
     return yup.object().shape(
-      Object.values(fieldInstructionBundle)
-        .map((fieldInstructionAny) =>
-          configFromFieldInstructionAny(fieldInstructionAny)
-        )
-        .reduce(
-          (acc: { [key: string]: yup.AnySchema }, config: FieldConfig) => {
-            acc[config.name] =
-              typeof config.validator === "function"
-                ? config.validator(formValues)
-                : config.validator ?? yup.mixed().optional();
-            return acc;
-          },
-          {}
-        )
+      Object.keys(fieldInstructionBundle).reduce(
+        (acc: { [key: string]: yup.AnySchema }, fieldName: string) => {
+          const config: FieldConfig = configFromFieldInstructionAny(
+            fieldInstructionBundle[fieldName]
+          );
+          acc[fieldName] =
+            typeof config.validator === "function"
+              ? config.validator(formValues)
+              : config.validator ?? yup.mixed().optional();
+          return acc;
+        },
+        {}
+      )
     );
   });
 };

--- a/src/forms/formUtils.ts
+++ b/src/forms/formUtils.ts
@@ -100,7 +100,7 @@ export const validationSchemaFromFieldInstructionBundle = (
     return yup.object().shape(
       Object.keys(fieldInstructionBundle).reduce(
         (acc: { [key: string]: yup.AnySchema }, fieldName: string) => {
-          const config: FieldConfig = configFromFieldInstructionAny(
+          const config = configFromFieldInstructionAny(
             fieldInstructionBundle[fieldName]
           );
           acc[fieldName] =

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,15 +6,13 @@ import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 
 const containerElement = document.getElementById("root") as HTMLElement;
-const root = createRoot(
-  containerElement
-);
+const root = createRoot(containerElement);
 
 root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-)
+  </React.StrictMode>
+);
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))


### PR DESCRIPTION
Refactored to derive the names of fields from the field instruction bundles rather than specifying the field name as part of the field config. Some other refactoring and cleanup was performed as well.